### PR TITLE
Fix Job constructor defaults

### DIFF
--- a/economy/jobs.py
+++ b/economy/jobs.py
@@ -22,9 +22,13 @@ JobTool = namedtuple('JobTool', ['tool','qty','break_chance'])
 class Job(object):
     __slots__ = ('__inputs','__outputs','__tools','__name','__limit')
 
-    def __init__(self, name, inputs=[], outputs=[], tools=[], limit=None):
+    def __init__(self, name, inputs=None, outputs=None, tools=None, limit=None):
         self.__name = name
         self.__limit = limit
+
+        inputs = inputs or []
+        outputs = outputs or []
+        tools = tools or []
 
         self.__inputs = ()
         for step in inputs:


### PR DESCRIPTION
## Summary
- fix `Job.__init__` to avoid mutable defaults

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6862a624d7588324a6e1639fe78bd105