### PR TITLE
Fix crash and improve YAML loading

### DIFF
--- a/economy/goods.py
+++ b/economy/goods.py
@@ -23,6 +23,6 @@ class Good(namedtuple('Good', ['name','size'])):
 
 
 with open('data/goods.yml') as fh:
-    for good in yaml.load(fh):
+    for good in yaml.safe_load(fh):
         Good(**good)
 

--- a/economy/jobs.py
+++ b/economy/jobs.py
@@ -74,6 +74,6 @@ class Job(object):
 
 
 with open('data/jobs.yml') as fh:
-    for job in yaml.load(fh):
+    for job in yaml.safe_load(fh):
         Job(**job)
 

--- a/economy/market/market.py
+++ b/economy/market/market.py
@@ -52,13 +52,18 @@ class Market(object):
 
                     profit_by_job[agent.job] = job_profit
 
-                profits = []
-                for job in profit_by_job:
-                    profits.append((profit_by_job[job][0]/profit_by_job[job][1], job))
+                if profit_by_job:
+                    profits = []
+                    for job in profit_by_job:
+                        profits.append((profit_by_job[job][0]/profit_by_job[job][1], job))
 
-                profits.sort(key=lambda x: x[0], reverse=True)
+                    profits.sort(key=lambda x: x[0], reverse=True)
+                    next_job = jobs.by_name(profits[0][1])
+                else:
+                    # No surviving agents to base profits on; pick a random job
+                    next_job = random.choice(list(jobs.all()))
 
-                agents.append(Agent(jobs.by_name(profits[0][1]), self))
+                agents.append(Agent(next_job, self))
 
             self._agents = agents
 


### PR DESCRIPTION
## Summary
- replace deprecated `yaml.load` with `yaml.safe_load`
- prevent `Market.simulate` from crashing when all agents go bankrupt

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6862a4832c4883248670438e662baac0