### PR TITLE
Fix IPython Notebook header in gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,5 +61,5 @@ docs/_build/
 # PyBuilder
 target/
 
-#Ipython Notebook
+# IPython Notebook
 .ipynb_checkpoints


### PR DESCRIPTION
## Summary
- update spelling in `.gitignore` header

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6862a88391088324b71035b2219f2ad9