### PR TITLE
Add Flask GUI

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,3 +66,13 @@ pip install -r requirements.txt
 
 After activating the environment, the unit tests can be executed with `pytest`.
 
+
+## Running the Flask GUI
+
+A simple Flask application is provided in `gui/app.py`. After installing the requirements you can launch the web interface with:
+
+```bash
+python gui/app.py
+```
+
+Open your browser at [http://localhost:5000](http://localhost:5000) to configure and run a simulation.

--- a/gui/app.py
+++ b/gui/app.py
@@ -1,0 +1,26 @@
+from flask import Flask, render_template, request
+from economy.market.market import Market
+
+app = Flask(__name__)
+
+@app.route('/', methods=['GET', 'POST'])
+def index():
+    if request.method == 'POST':
+        num_agents = int(request.form.get('num_agents', 9))
+        days = int(request.form.get('days', 1))
+        market = Market(num_agents=num_agents)
+        market.simulate(days)
+        results = {}
+        for good in market.history():
+            low, high, current, ratio = market.aggregate(good)
+            results[good] = {
+                'low': low,
+                'high': high,
+                'current': current,
+                'ratio': ratio,
+            }
+        return render_template('results.html', results=results, days=days)
+    return render_template('index.html')
+
+if __name__ == '__main__':
+    app.run(debug=True)

--- a/gui/templates/index.html
+++ b/gui/templates/index.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<html>
+  <head>
+    <title>Star Trader Simulation</title>
+  </head>
+  <body>
+    <h1>Run Simulation</h1>
+    <form method="post">
+      <label for="num_agents">Number of Agents:</label>
+      <input type="number" id="num_agents" name="num_agents" value="9" min="1" />
+      <br/>
+      <label for="days">Days:</label>
+      <input type="number" id="days" name="days" value="5" min="1" />
+      <br/>
+      <input type="submit" value="Run" />
+    </form>
+  </body>
+</html>

--- a/gui/templates/results.html
+++ b/gui/templates/results.html
@@ -1,0 +1,26 @@
+<!doctype html>
+<html>
+  <head>
+    <title>Results</title>
+  </head>
+  <body>
+    <h1>Results for {{ days }} day(s)</h1>
+    <table border="1">
+      <tr>
+        <th>Good</th>
+        <th>Low</th>
+        <th>High</th>
+        <th>Current</th>
+      </tr>
+      {% for good, data in results.items() %}
+      <tr>
+        <td>{{ good }}</td>
+        <td>{{ data.low }}</td>
+        <td>{{ data.high }}</td>
+        <td>{{ data.current }}</td>
+      </tr>
+      {% endfor %}
+    </table>
+    <p><a href="/">Run another simulation</a></p>
+  </body>
+</html>

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ pyyaml
 numpy
 matplotlib
 pytest
+flask


### PR DESCRIPTION
## Summary
- create a minimal Flask app in `gui/app.py`
- add HTML templates to configure the simulation and show results
- update requirements to include Flask
- document how to run the GUI in the README

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6862b3e23f1483248f947acc45c98cf0