### PR TITLE
Fix imports when running modules directly

### DIFF
--- a/gui/app.py
+++ b/gui/app.py
@@ -1,5 +1,17 @@
 from flask import Flask, render_template, request
 
+# Ensure the project root is on the Python path when running this module
+# directly (e.g. `python gui/app.py`). This allows imports like
+# `from economy import Market` to succeed even if the current working
+# directory is the `gui/` folder.
+if __package__ is None:  # pragma: no cover - executed only when run directly
+    import sys
+    from pathlib import Path
+
+    project_root = Path(__file__).resolve().parents[1]
+    if str(project_root) not in sys.path:
+        sys.path.insert(0, str(project_root))
+
 from economy import Market
 
 app = Flask(__name__)

--- a/tests/test_inventory.py
+++ b/tests/test_inventory.py
@@ -1,5 +1,11 @@
 import unittest
 
+# Ensure the project root is on the Python path so that imports from the
+# `economy` package succeed when tests are run directly or via pytest.
+import sys
+from pathlib import Path
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
 from economy.agent import Inventory
 
 


### PR DESCRIPTION
## Summary
- make GUI executable directly by inserting project root into `sys.path`
- ensure unit tests can import the project by adjusting `sys.path`

## Testing
- `pytest -q`
- `python gui/app.py` (verified server starts)

------
https://chatgpt.com/codex/tasks/task_e_6862b60a0ea48324bd7abd49e3d7d327