### PR TITLE
Add daily price breakdown to GUI

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,3 +76,5 @@ python gui/app.py
 ```
 
 Open your browser at [http://localhost:5000](http://localhost:5000) to configure and run a simulation.
+
+The results page now includes a table showing the average price of each good for every simulated day, allowing you to track price trends over time.

--- a/gui/app.py
+++ b/gui/app.py
@@ -23,15 +23,22 @@ def index():
         days = int(request.form.get('days', 1))
         market = Market(num_agents=num_agents)
         market.simulate(days)
+
+        # Collect aggregated statistics and daily price history
+        hist = market.history(days)
         results = {}
-        for good in market.history():
-            low, high, current, ratio = market.aggregate(good)
+        for good in hist:
+            low, high, current, ratio = market.aggregate(good, days)
+            # Extract mean price for each day (may be None if no trades)
+            prices = [trade.mean for trade in hist[good]]
             results[good] = {
                 'low': low,
                 'high': high,
                 'current': current,
                 'ratio': ratio,
+                'prices': prices,
             }
+
         return render_template('results.html', results=results, days=days)
     return render_template('index.html')
 

--- a/gui/templates/results.html
+++ b/gui/templates/results.html
@@ -23,6 +23,24 @@
       </tr>
       {% endfor %}
     </table>
+
+    <h2>Daily Prices</h2>
+    <table class="hover">
+      <tr>
+        <th>Good</th>
+        {% for day in range(1, days + 1) %}
+        <th>Day {{ day }}</th>
+        {% endfor %}
+      </tr>
+      {% for good, data in results.items() %}
+      <tr>
+        <td>{{ good }}</td>
+        {% for price in data.prices %}
+        <td>{% if price is none %}N/A{% else %}{{ price }}{% endif %}</td>
+        {% endfor %}
+      </tr>
+      {% endfor %}
+    </table>
     <p><a href="/">Run another simulation</a></p>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- collect daily prices during simulation
- display daily price breakdown on the results page
- mention new results table in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6862b87766f48324af63fc223bf46733