### PR TITLE
Add agent stats section

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,3 +78,4 @@ python gui/app.py
 Open your browser at [http://localhost:5000](http://localhost:5000) to configure and run a simulation.
 
 The results page now includes a table showing the average price of each good for every simulated day, allowing you to track price trends over time.
+It also lists statistics for each agent, including their final money and total profit, so you can compare how well different strategies performed.

--- a/economy/agent.py
+++ b/economy/agent.py
@@ -73,6 +73,8 @@ class Agent(object):
     _money = 0
     _money_last_round = 0
     _name = None
+    _initial_money = 0
+    _trade_stats = None
     beliefs = None
 
     def __init__(self, recipe, market, initial_inv=10, initial_money=100):
@@ -80,7 +82,10 @@ class Agent(object):
         self._market = market
         self._money = initial_money
         self._money_last_round = initial_money
+        self._initial_money = initial_money
         self._name = AGENT_NAMES.pop()
+
+        self._trade_stats = {}
 
         self.beliefs = Beliefs()
 
@@ -97,6 +102,18 @@ class Agent(object):
     @property
     def job(self):
         return str(self._recipe)
+
+    @property
+    def name(self):
+        return self._name
+
+    @property
+    def money(self):
+        return self._money
+
+    @property
+    def total_profit(self):
+        return self._money - self._initial_money
 
     @property
     def profit(self):
@@ -171,6 +188,18 @@ class Agent(object):
     def give_items(self, item, amt, other):
         self._inventory.remove_item(item, amt)
         other._inventory.add_item(item, amt)
+
+    def record_purchase(self, good, qty):
+        stats = self._trade_stats.setdefault(good, {'bought': 0, 'sold': 0})
+        stats['bought'] += qty
+
+    def record_sale(self, good, qty):
+        stats = self._trade_stats.setdefault(good, {'bought': 0, 'sold': 0})
+        stats['sold'] += qty
+
+    @property
+    def trade_stats(self):
+        return self._trade_stats
 
     def _determine_trade_quantity(self, good, base_qty, buying=False, default=0.75):
         if base_qty <= 0:

--- a/economy/market/book.py
+++ b/economy/market/book.py
@@ -72,6 +72,8 @@ class OrderBook(object):
 
             bid.agent.give_money(qty * price, ask.agent)
             ask.agent.give_items(good, qty, bid.agent)
+            bid.agent.record_purchase(good, qty)
+            ask.agent.record_sale(good, qty)
 
             bid.agent.beliefs.update(good, price)
             ask.agent.beliefs.update(good, price)

--- a/economy/market/market.py
+++ b/economy/market/market.py
@@ -133,3 +133,15 @@ class Market(object):
 
     def aggregate(self, good, depth=None):
         return self._history.aggregate(good, depth)
+
+    def agent_stats(self):
+        stats = []
+        for agent in self._agents:
+            stats.append({
+                'name': agent.name,
+                'job': agent.job,
+                'money': agent.money,
+                'profit': agent.total_profit,
+                'trades': agent.trade_stats,
+            })
+        return stats

--- a/gui/app.py
+++ b/gui/app.py
@@ -39,7 +39,9 @@ def index():
                 'prices': prices,
             }
 
-        return render_template('results.html', results=results, days=days)
+        agent_stats = market.agent_stats()
+
+        return render_template('results.html', results=results, days=days, agents=agent_stats)
     return render_template('index.html')
 
 if __name__ == '__main__':

--- a/gui/templates/results.html
+++ b/gui/templates/results.html
@@ -41,6 +41,24 @@
       </tr>
       {% endfor %}
     </table>
+
+    <h2>Agent Stats</h2>
+    <table class="hover">
+      <tr>
+        <th>Name</th>
+        <th>Job</th>
+        <th>Money</th>
+        <th>Total Profit</th>
+      </tr>
+      {% for agent in agents %}
+      <tr>
+        <td>{{ agent.name }}</td>
+        <td>{{ agent.job }}</td>
+        <td>{{ agent.money }}</td>
+        <td>{{ agent.profit }}</td>
+      </tr>
+      {% endfor %}
+    </table>
     <p><a href="/">Run another simulation</a></p>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- track trade history and profits for each agent
- expose aggregated stats from `Market.agent_stats`
- display agent stats in the Flask results page
- document the new results table in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6862ba035e048324bd4e2ee3094c451f