### PR TITLE
Add sqlite persistence and CLI controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,13 @@ market.simulate(5)
 
 This will print out each agent's activity and the trades executed on each day.
 
+### Persisting simulation data
+
+`simulate.py` provides a small command line interface that stores all
+trade history in a SQLite database. Run `python simulate.py --step` to
+advance the existing simulation by one day or `python simulate.py --reset`
+to start over from scratch.
+
 ## Setup
 
 The project can be run inside a virtual environment to isolate its
@@ -78,3 +85,6 @@ python gui/app.py
 Open your browser at [http://localhost:5000](http://localhost:5000) to configure and run a simulation.
 
 The results page now includes a table showing the average price of each good for every simulated day, allowing you to track price trends over time.
+
+The web interface persists trade history using SQLite. Click **Simulate** to
+advance by the selected number of days or **Reset Simulation** to start over.

--- a/economy/__init__.py
+++ b/economy/__init__.py
@@ -1,6 +1,11 @@
 from .agent import Agent
-
-__all__ = ['Agent']
+try:
+    from .market.history import SQLiteHistory
+except Exception:  # pragma: no cover - optional dependency
+    SQLiteHistory = None
+    __all__ = ['Agent']
+else:
+    __all__ = ['Agent', 'SQLiteHistory']
 
 # try:
 from .market import Market

--- a/economy/market/market.py
+++ b/economy/market/market.py
@@ -12,10 +12,10 @@ class Market(object):
     _book = None
     _history = None
 
-    def __init__(self, num_agents=15):
+    def __init__(self, num_agents=15, history=None):
         self._agents = []
         self._book = OrderBook()
-        self._history = MarketHistory()
+        self._history = history if history is not None else MarketHistory()
 
         job_list = list(jobs.all())
         if not job_list:

--- a/gui/templates/index.html
+++ b/gui/templates/index.html
@@ -7,14 +7,19 @@
   </head>
   <body class="grid-container">
     <h1>Run Simulation</h1>
+    {% if message %}<p>{{ message }}</p>{% endif %}
     <form method="post">
       <label for="num_agents">Number of Agents:</label>
       <input type="number" id="num_agents" name="num_agents" value="9" min="1" class="input-number">
       <br/>
-      <label for="days">Days:</label>
-      <input type="number" id="days" name="days" value="5" min="1" class="input-number">
+      <label for="days">Days to Simulate:</label>
+      <input type="number" id="days" name="days" value="1" min="1" class="input-number">
       <br/>
-      <input type="submit" value="Run" class="button">
+      <input type="submit" value="Simulate" class="button">
+    </form>
+    <form method="post" style="margin-top: 1em;">
+      <input type="hidden" name="reset" value="1">
+      <input type="submit" value="Reset Simulation" class="alert button">
     </form>
   </body>
 </html>

--- a/gui/templates/results.html
+++ b/gui/templates/results.html
@@ -6,7 +6,7 @@
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/foundation-sites/dist/css/foundation.min.css">
   </head>
   <body class="grid-container">
-    <h1>Results for {{ days }} day(s)</h1>
+    <h1>Results for {{ days }} day(s) (Day {{ day_number }})</h1>
     <table class="hover">
       <tr>
         <th>Good</th>

--- a/simulate.py
+++ b/simulate.py
@@ -1,0 +1,28 @@
+import argparse
+
+from economy.market.market import Market
+from economy.market.history import SQLiteHistory
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Run or control the Star Trader simulation")
+    parser.add_argument("--step", type=int, default=1, help="Number of days to simulate (default: 1)")
+    parser.add_argument("--reset", action="store_true", help="Reset stored simulation data")
+    parser.add_argument("--num-agents", type=int, default=9, help="Number of agents when starting a new simulation")
+    parser.add_argument("--db", default="sim.db", help="SQLite database file")
+    args = parser.parse_args()
+
+    history = SQLiteHistory(db_path=args.db)
+
+    if args.reset:
+        history.reset()
+        print("Simulation reset.")
+        return
+
+    market = Market(num_agents=args.num_agents, history=history)
+    market.simulate(args.step)
+    print(f"Simulated up to day {history.day_number}.")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- persist market history in a new `SQLiteHistory` class
- allow passing a custom history object into `Market`
- add `simulate.py` script to step through or reset simulations
- expose `SQLiteHistory` from the package
- document the new persistence options in the README
- add simulation controls to Flask GUI

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6862ba82e328832498afeeb4d329aa86