### PR TITLE
Add agent trade stats to frontend

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,4 +85,4 @@ python gui/app.py
 Open your browser at [http://localhost:5000](http://localhost:5000) to configure and run a simulation.
 
 The results page now includes a table showing the average price of each good for every simulated day, allowing you to track price trends over time.
-It also lists statistics for each agent, including their final money and total profit, so you can compare how well different strategies performed.
+It also lists statistics for each agent, including their final money and total profit, so you can compare how well different strategies performed. An additional table breaks down how many units of each good every agent bought and sold during the run.

--- a/economy/agent.py
+++ b/economy/agent.py
@@ -201,6 +201,13 @@ class Agent(object):
     def trade_stats(self):
         return self._trade_stats
 
+    @property
+    def trade_totals(self):
+        """Return total units bought and sold across all goods."""
+        bought = sum(v['bought'] for v in self._trade_stats.values())
+        sold = sum(v['sold'] for v in self._trade_stats.values())
+        return {'bought': bought, 'sold': sold}
+
     def _determine_trade_quantity(self, good, base_qty, buying=False, default=0.75):
         if base_qty <= 0:
             return 0

--- a/economy/market/market.py
+++ b/economy/market/market.py
@@ -143,5 +143,6 @@ class Market(object):
                 'money': agent.money,
                 'profit': agent.total_profit,
                 'trades': agent.trade_stats,
+                'trade_totals': agent.trade_totals,
             })
         return stats

--- a/gui/templates/results.html
+++ b/gui/templates/results.html
@@ -59,6 +59,33 @@
       </tr>
       {% endfor %}
     </table>
+
+    <h2>Agent Trade Stats</h2>
+    <table class="hover">
+      <tr>
+        <th>Name</th>
+        <th>Good</th>
+        <th>Bought</th>
+        <th>Sold</th>
+      </tr>
+      {% for agent in agents %}
+        {% if agent.trades %}
+          {% for good, data in agent.trades.items() %}
+          <tr>
+            <td>{{ agent.name }}</td>
+            <td>{{ good }}</td>
+            <td>{{ data.bought }}</td>
+            <td>{{ data.sold }}</td>
+          </tr>
+          {% endfor %}
+        {% else %}
+          <tr>
+            <td>{{ agent.name }}</td>
+            <td colspan="3">No trades</td>
+          </tr>
+        {% endif %}
+      {% endfor %}
+    </table>
     <p><a href="/">Run another simulation</a></p>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- track total trades per agent
- expose trade statistics through `Market.agent_stats`
- display trade breakdown in the results page
- document new table in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6862c1b0939c83248e695269cc3ccb93