### PR TITLE
Add Chart.js charts and JSON API

### DIFF
--- a/gui/templates/results.html
+++ b/gui/templates/results.html
@@ -4,6 +4,8 @@
     <title>Results</title>
     <!-- Include the Foundation CSS framework -->
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/foundation-sites/dist/css/foundation.min.css">
+    <!-- Chart.js for interactive charts -->
+    <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
   </head>
   <body class="grid-container">
     <h1>Results for {{ days }} day(s)</h1>
@@ -23,6 +25,15 @@
       </tr>
       {% endfor %}
     </table>
+
+    <h2>Price and Volume Charts</h2>
+    {% set idx = 1 %}
+    {% for good, data in results.items() %}
+    <h3>{{ good }}</h3>
+    <canvas id="priceChart-{{ idx }}" width="400" height="200"></canvas>
+    <canvas id="volumeChart-{{ idx }}" width="400" height="200"></canvas>
+    {% set idx = idx + 1 %}
+    {% endfor %}
 
     <h2>Daily Prices</h2>
     <table class="hover">
@@ -60,5 +71,41 @@
       {% endfor %}
     </table>
     <p><a href="/">Run another simulation</a></p>
+    <script>
+      const results = {{ results|tojson }};
+      const days = {{ days }};
+      const labels = Array.from({length: days}, (_, i) => `Day ${i+1}`);
+      let idx = 1;
+      for (const [good, data] of Object.entries(results)) {
+        const priceCtx = document.getElementById(`priceChart-${idx}`).getContext('2d');
+        new Chart(priceCtx, {
+          type: 'line',
+          data: {
+            labels: labels,
+            datasets: [{
+              label: `${good} Price`,
+              data: data.prices,
+              fill: false,
+              borderColor: 'blue'
+            }]
+          },
+          options: {responsive: false}
+        });
+        const volCtx = document.getElementById(`volumeChart-${idx}`).getContext('2d');
+        new Chart(volCtx, {
+          type: 'bar',
+          data: {
+            labels: labels,
+            datasets: [{
+              label: `${good} Volume`,
+              data: data.volumes,
+              backgroundColor: 'orange'
+            }]
+          },
+          options: {responsive: false}
+        });
+        idx++;
+      }
+    </script>
   </body>
 </html>

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,0 +1,28 @@
+import json
+import unittest
+from pathlib import Path
+import sys
+
+# Ensure project root is on path
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from gui.app import app
+
+class TestSimulationAPI(unittest.TestCase):
+    def setUp(self):
+        app.testing = True
+        self.client = app.test_client()
+
+    def test_json_response(self):
+        resp = self.client.post('/', data={'num_agents': 3, 'days': 1}, headers={'Accept': 'application/json'})
+        self.assertEqual(resp.status_code, 200)
+        self.assertTrue(resp.is_json)
+        data = resp.get_json()
+        self.assertIn('results', data)
+        self.assertIn('agents', data)
+        good = next(iter(data['results']))
+        self.assertIn('prices', data['results'][good])
+        self.assertIn('volumes', data['results'][good])
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- return price/volume data as JSON when the client requests it
- show interactive price and volume charts via Chart.js
- test API JSON response

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6862c17d2cb48324b59149abc69ffd51