### PR TITLE
Add persistent simulation controls

### DIFF
--- a/economy/market/history.py
+++ b/economy/market/history.py
@@ -142,7 +142,7 @@ class SQLiteHistory(MarketHistory):
             self._history[good] = []
             cur = self._conn.execute(
                 "SELECT volume, low, high, mean, supply, demand FROM trades WHERE good=? ORDER BY day",
-                (good,),
+                (str(good),),
             )
             for r in cur.fetchall():
                 self._history[good].append(Trades(*r))
@@ -157,7 +157,7 @@ class SQLiteHistory(MarketHistory):
                 "INSERT INTO trades(day, good, volume, low, high, mean, supply, demand) VALUES (?,?,?,?,?,?,?,?)",
                 (
                     day,
-                    good,
+                    str(good),
                     trades.volume,
                     trades.low,
                     trades.high,

--- a/gui/templates/index.html
+++ b/gui/templates/index.html
@@ -6,15 +6,32 @@
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/foundation-sites/dist/css/foundation.min.css">
   </head>
   <body class="grid-container">
-    <h1>Run Simulation</h1>
-    <form method="post">
+<h1>Run Simulation</h1>
+<form method="post">
       <label for="num_agents">Number of Agents:</label>
       <input type="number" id="num_agents" name="num_agents" value="9" min="1" class="input-number">
       <br/>
       <label for="days">Days:</label>
       <input type="number" id="days" name="days" value="5" min="1" class="input-number">
       <br/>
-      <input type="submit" value="Run" class="button">
-    </form>
+  <input type="submit" value="Run" class="button">
+</form>
+
+  <h2>Persistent Simulation</h2>
+  <form action="/step" method="post">
+    <label for="p_days">Days to Step:</label>
+    <input type="number" id="p_days" name="days" value="1" min="1" class="input-number">
+    <input type="submit" value="Step" class="button">
+  </form>
+  <form action="/reset" method="post">
+    <label for="p_agents">Agents:</label>
+    <input type="number" id="p_agents" name="num_agents" value="9" min="1" class="input-number">
+    <input type="submit" value="Reset" class="button alert">
+  </form>
+  <form action="/load" method="get">
+    <label for="db">DB File:</label>
+    <input type="text" id="db" name="db" value="sim.db">
+    <input type="submit" value="Load" class="button secondary">
+  </form>
   </body>
 </html>

--- a/gui/templates/results.html
+++ b/gui/templates/results.html
@@ -97,6 +97,15 @@
         {% endif %}
       {% endfor %}
     </table>
+    <h2>Simulation Controls</h2>
+    <form action="/step" method="post">
+      <label for="cont_days">Days to Step:</label>
+      <input type="number" id="cont_days" name="days" value="1" min="1" class="input-number">
+      <input type="submit" value="Step" class="button">
+    </form>
+    <form action="/reset" method="post">
+      <input type="submit" value="Reset" class="button alert">
+    </form>
     <p><a href="/">Run another simulation</a></p>
     <script>
       const results = {{ results|tojson }};

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -24,5 +24,26 @@ class TestSimulationAPI(unittest.TestCase):
         self.assertIn('prices', data['results'][good])
         self.assertIn('volumes', data['results'][good])
 
+    def test_step_and_reset(self):
+        # Reset to ensure clean state
+        resp = self.client.post('/reset', json={'num_agents': 2})
+        self.assertEqual(resp.status_code, 200)
+        self.assertTrue(resp.is_json)
+        data = resp.get_json()
+        self.assertEqual(data['days'], 0)
+
+        # Step one day
+        resp = self.client.post('/step', json={'days': 1})
+        self.assertEqual(resp.status_code, 200)
+        self.assertTrue(resp.is_json)
+        data = resp.get_json()
+        self.assertEqual(data['days'], 1)
+
+        # Step another day and ensure day counter increases
+        resp = self.client.post('/step', json={'days': 1})
+        self.assertEqual(resp.status_code, 200)
+        data = resp.get_json()
+        self.assertEqual(data['days'], 2)
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary
- persist data across GUI sessions by creating a global SQLite-backed `Market`
- allow stepping, resetting, and loading a database via new `/step`, `/reset`, and `/load` routes
- extend pages with forms to trigger the new actions
- adapt `SQLiteHistory` to store goods as text
- add tests for persistent API functions

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6862c3958c1c8324a3aa71cf326cba65