### PR TITLE
Add custom job counts and starting parameters

### DIFF
--- a/gui/templates/index.html
+++ b/gui/templates/index.html
@@ -14,6 +14,23 @@
       <label for="days">Days:</label>
       <input type="number" id="days" name="days" value="5" min="1" class="input-number">
       <br/>
+      <label for="initial_money">Initial Money:</label>
+      <input type="number" id="initial_money" name="initial_money" value="100" min="0" class="input-number">
+      <br/>
+      <label for="initial_inv">Initial Inventory:</label>
+      <input type="number" id="initial_inv" name="initial_inv" value="10" min="0" class="input-number">
+      <br/>
+      {% if jobs %}
+      <fieldset>
+        <legend>Agents Per Job</legend>
+        {% for job in jobs %}
+          {% set slug = job.replace(' ', '_') %}
+          <label for="job_{{ slug }}">{{ job }}</label>
+          <input type="number" id="job_{{ slug }}" name="job_{{ slug }}" value="0" min="0" class="input-number">
+          <br/>
+        {% endfor %}
+      </fieldset>
+      {% endif %}
   <input type="submit" value="Run" class="button">
 </form>
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -45,5 +45,20 @@ class TestSimulationAPI(unittest.TestCase):
         data = resp.get_json()
         self.assertEqual(data['days'], 2)
 
+    def test_job_distribution(self):
+        payload = {
+            'days': 1,
+            'job_Sand_Digger': 2,
+            'job_Glass_Maker': 1
+        }
+        resp = self.client.post('/', data=payload,
+                               headers={'Accept': 'application/json'})
+        self.assertEqual(resp.status_code, 200)
+        self.assertTrue(resp.is_json)
+        data = resp.get_json()
+        jobs = [agent['job'] for agent in data['agents']]
+        self.assertEqual(jobs.count('Sand Digger'), 2)
+        self.assertEqual(jobs.count('Glass Maker'), 1)
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary
- allow specifying job distribution, starting inventory and money when creating `Market`
- expose new options in the Flask GUI
- display form fields for agent counts per job and initial resources
- test custom job distribution via API

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6862c7ca9b74832489c07e46dcfc67e5