### PR TITLE
Add SQLite storage for goods and jobs

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,8 @@ available goods and tools and adjust their beliefs about prices over time.
 └── economy/   # Python package implementing the simulation
     ├── agent.py       # Agent behaviour and inventory management
     ├── beliefs.py     # Price beliefs used by agents
-    ├── goods.py       # Load goods from `data/goods.yml`
-    ├── jobs.py        # Load jobs from `data/jobs.yml`
+    ├── goods.py       # Load goods from the database
+    ├── jobs.py        # Load jobs from the database
     ├── offer.py       # Ask/Bid definitions
     └── market/        # Market engine and order book
         ├── market.py  # `Market` class and simulation loop
@@ -24,9 +24,10 @@ available goods and tools and adjust their beliefs about prices over time.
 
 ### `data/`
 
-The `data` folder contains YAML configuration files. `goods.yml` lists all tradeable
-goods and their storage size while `jobs.yml` defines the jobs that agents can
-perform, including the required inputs and produced outputs.
+The `data` folder contains YAML configuration files used to seed the
+database. `goods.yml` lists the available goods while `jobs.yml` defines the
+job recipes. On the first run the database tables are populated from these
+files and subsequent runs load the definitions from SQLite.
 
 ### `economy/`
 

--- a/economy/db.py
+++ b/economy/db.py
@@ -1,0 +1,12 @@
+import os
+import sqlite3
+
+# Reuse the same database file as the simulation history so that all
+# persistent data lives together. Users can override the path via the
+# STAR_TRADER_DB environment variable.
+DB_PATH = os.environ.get("STAR_TRADER_DB", "sim.db")
+
+
+def get_connection():
+    """Return a connection to the shared SQLite database."""
+    return sqlite3.connect(DB_PATH)

--- a/economy/goods.py
+++ b/economy/goods.py
@@ -1,8 +1,13 @@
 from collections import namedtuple
+import os
 import yaml
+
+from . import db
+
 
 
 _by_name = {}
+
 def by_name(name):
     return _by_name[name.lower()]
 
@@ -22,7 +27,31 @@ class Good(namedtuple('Good', ['name','size'])):
         return self.name
 
 
-with open('data/goods.yml') as fh:
-    for good in yaml.safe_load(fh):
-        Good(**good)
+
+def _load_goods():
+    """Load goods from the database, populating tables from YAML if needed."""
+    conn = db.get_connection()
+    with conn:
+        conn.execute(
+            """CREATE TABLE IF NOT EXISTS goods(
+                    name TEXT PRIMARY KEY,
+                    size REAL
+                )"""
+        )
+        cur = conn.execute("SELECT name, size FROM goods")
+        rows = cur.fetchall()
+        if not rows:
+            with open(os.path.join("data", "goods.yml")) as fh:
+                data = yaml.safe_load(fh)
+            conn.executemany(
+                "INSERT INTO goods(name, size) VALUES (?, ?)",
+                [(g["name"], g["size"]) for g in data],
+            )
+            rows = [(g["name"], g["size"]) for g in data]
+
+    for name, size in rows:
+        Good(name=name, size=size)
+
+
+_load_goods()
 

--- a/economy/jobs.py
+++ b/economy/jobs.py
@@ -1,5 +1,8 @@
 from collections import namedtuple
+import os
 import yaml
+
+from . import db
 
 
 from . import goods
@@ -77,7 +80,96 @@ class Job(object):
         return self.__name
 
 
-with open('data/jobs.yml') as fh:
-    for job in yaml.safe_load(fh):
-        Job(**job)
+
+def _load_jobs():
+    """Load job definitions from the database, using YAML as a seed if empty."""
+    conn = db.get_connection()
+    with conn:
+        conn.execute(
+            """CREATE TABLE IF NOT EXISTS jobs(
+                    name TEXT PRIMARY KEY,
+                    job_limit INTEGER
+                )"""
+        )
+        conn.execute(
+            """CREATE TABLE IF NOT EXISTS job_inputs(
+                    job TEXT,
+                    good TEXT,
+                    qty INTEGER
+                )"""
+        )
+        conn.execute(
+            """CREATE TABLE IF NOT EXISTS job_outputs(
+                    job TEXT,
+                    good TEXT,
+                    qty INTEGER
+                )"""
+        )
+        conn.execute(
+            """CREATE TABLE IF NOT EXISTS job_tools(
+                    job TEXT,
+                    tool TEXT,
+                    qty INTEGER,
+                    break_chance REAL
+                )"""
+        )
+
+        cur = conn.execute("SELECT name, job_limit FROM jobs")
+        rows = cur.fetchall()
+        if not rows:
+            with open(os.path.join("data", "jobs.yml")) as fh:
+                data = yaml.safe_load(fh)
+            for job in data:
+                conn.execute(
+                    "INSERT INTO jobs(name, job_limit) VALUES (?, ?)",
+                    (job["name"], job.get("limit")),
+                )
+                for step in job.get("inputs", []):
+                    conn.execute(
+                        "INSERT INTO job_inputs(job, good, qty) VALUES (?, ?, ?)",
+                        (job["name"], step["good"], step["qty"]),
+                    )
+                for step in job.get("outputs", []):
+                    conn.execute(
+                        "INSERT INTO job_outputs(job, good, qty) VALUES (?, ?, ?)",
+                        (job["name"], step["good"], step["qty"]),
+                    )
+                for tool in job.get("tools", []):
+                    conn.execute(
+                        "INSERT INTO job_tools(job, tool, qty, break_chance) VALUES (?, ?, ?, ?)",
+                        (
+                            job["name"],
+                            tool["tool"],
+                            tool["qty"],
+                            tool["break_chance"],
+                        ),
+                    )
+            rows = conn.execute("SELECT name, job_limit FROM jobs").fetchall()
+
+    for name, job_limit in rows:
+        inputs = [
+            {"good": r[0], "qty": r[1]}
+            for r in conn.execute(
+                "SELECT good, qty FROM job_inputs WHERE job=?", (name,)
+            ).fetchall()
+        ]
+        outputs = [
+            {"good": r[0], "qty": r[1]}
+            for r in conn.execute(
+                "SELECT good, qty FROM job_outputs WHERE job=?", (name,)
+            ).fetchall()
+        ]
+        tools = [
+            {"tool": r[0], "qty": r[1], "break_chance": r[2]}
+            for r in conn.execute(
+                "SELECT tool, qty, break_chance FROM job_tools WHERE job=?",
+                (name,),
+            ).fetchall()
+        ]
+        Job(name=name, inputs=inputs, outputs=outputs, tools=tools, limit=job_limit)
+
+    conn.close()
+
+
+_load_jobs()
 


### PR DESCRIPTION
## Summary
- load goods and jobs from a shared SQLite database
- seed database tables from existing YAML files on first run
- update documentation to explain new database storage

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6862d0a42d2083248756f721a8b91e3a