### PR TITLE
Add Market Overview view

### DIFF
--- a/economy/agent.py
+++ b/economy/agent.py
@@ -75,6 +75,7 @@ class Agent(object):
     _name = None
     _initial_money = 0
     _trade_stats = None
+    _age = 0
     beliefs = None
 
     def __init__(self, recipe, market, initial_inv=10, initial_money=100):
@@ -86,6 +87,7 @@ class Agent(object):
         self._name = f"{random.choice(FIRST_NAMES)} {random.choice(LAST_NAMES)}"
 
         self._trade_stats = {}
+        self._age = 0
 
         self.beliefs = Beliefs()
 
@@ -110,6 +112,10 @@ class Agent(object):
     @property
     def money(self):
         return self._money
+
+    @property
+    def age(self):
+        return self._age
 
     @property
     def total_profit(self):
@@ -207,6 +213,10 @@ class Agent(object):
         bought = sum(v['bought'] for v in self._trade_stats.values())
         sold = sum(v['sold'] for v in self._trade_stats.values())
         return {'bought': bought, 'sold': sold}
+
+    def advance_day(self):
+        """Increment the agent's age by one day."""
+        self._age += 1
 
     def _determine_trade_quantity(self, good, base_qty, buying=False, default=0.75):
         if base_qty <= 0:

--- a/gui/app.py
+++ b/gui/app.py
@@ -105,6 +105,15 @@ def _compile_results(market):
     return {'days': days, 'results': results, 'agents': agent_stats}
 
 
+@app.route('/overview', methods=['GET'])
+def overview():
+    """Return high level market overview for the persistent market."""
+    data = _persistent_market.overview_stats()
+    if request.accept_mimetypes['application/json'] >= request.accept_mimetypes['text/html']:
+        return jsonify(data)
+    return render_template('overview.html', **data)
+
+
 @app.route('/step', methods=['POST'])
 def step():
     """Advance the persistent simulation by N days."""

--- a/gui/templates/index.html
+++ b/gui/templates/index.html
@@ -50,5 +50,6 @@
     <input type="text" id="db" name="db" value="sim.db">
     <input type="submit" value="Load" class="button secondary">
   </form>
+  <p><a href="/overview">View Market Overview</a></p>
   </body>
 </html>

--- a/gui/templates/overview.html
+++ b/gui/templates/overview.html
@@ -1,0 +1,17 @@
+<!doctype html>
+<html>
+  <head>
+    <title>Market Overview</title>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/foundation-sites/dist/css/foundation.min.css">
+  </head>
+  <body class="grid-container">
+    <h1>Market Overview</h1>
+    <table class="hover">
+      <tr><th>Days Elapsed</th><td>{{ days_elapsed }}</td></tr>
+      <tr><th>Active Agents</th><td>{{ active_agents }}</td></tr>
+      <tr><th>Average Agent Age</th><td>{{ average_age|round(2) }}</td></tr>
+      <tr><th>Average Agent Lifespan</th><td>{{ average_lifespan|round(2) }}</td></tr>
+    </table>
+    <p><a href="/">Back</a></p>
+  </body>
+</html>

--- a/gui/templates/results.html
+++ b/gui/templates/results.html
@@ -106,7 +106,7 @@
     <form action="/reset" method="post">
       <input type="submit" value="Reset" class="button alert">
     </form>
-    <p><a href="/">Run another simulation</a></p>
+    <p><a href="/">Run another simulation</a> | <a href="/overview">Market Overview</a></p>
     <script>
       const results = {{ results|tojson }};
       const days = {{ days }};

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -60,5 +60,13 @@ class TestSimulationAPI(unittest.TestCase):
         self.assertEqual(jobs.count('Sand Digger'), 2)
         self.assertEqual(jobs.count('Glass Maker'), 1)
 
+    def test_overview_endpoint(self):
+        resp = self.client.get('/overview', headers={'Accept': 'application/json'})
+        self.assertEqual(resp.status_code, 200)
+        self.assertTrue(resp.is_json)
+        data = resp.get_json()
+        self.assertIn('days_elapsed', data)
+        self.assertIn('active_agents', data)
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary
- add age tracking for agents
- track agent lifespans in the market
- implement overview statistics in `Market`
- expose new `/overview` endpoint and template
- link from index/results pages to overview
- test new endpoint

## Testing
- `pip install -r requirements.txt`
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6862d36a8c10832483ba69766b4d057a