### PR TITLE
Add daily tax mechanism

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,11 +43,14 @@ A short example of starting a simulation is shown below:
 from economy import Market
 
 # Create a market with a handful of agents
-market = Market(num_agents=9)
+market = Market(num_agents=9, daily_tax=1)
 
 # Run the simulation for five days
 market.simulate(5)
 ```
+
+Passing ``daily_tax`` ensures agents must trade to stay solvent by deducting a
+flat amount of money each day.
 
 This will print out each agent's activity and the trades executed on each day.
 

--- a/economy/agent.py
+++ b/economy/agent.py
@@ -119,6 +119,10 @@ class Agent(object):
     def profit(self):
         return self._money - self._money_last_round
 
+    def apply_tax(self, amount):
+        """Deduct a flat tax from the agent's money."""
+        self._money -= amount
+
     @property
     def is_bankrupt(self):
         # TODO: TEMPORARY hack to prevent "harvesters"/"consumers" going bankrupt

--- a/economy/market/market.py
+++ b/economy/market/market.py
@@ -13,7 +13,7 @@ class Market(object):
     _history = None
 
     def __init__(self, num_agents=15, history=None, job_counts=None,
-                 initial_inv=10, initial_money=100):
+                 initial_inv=10, initial_money=100, daily_tax=0):
         """Create a new market instance.
 
         Parameters
@@ -31,11 +31,14 @@ class Market(object):
             Starting inventory quantity for each agent.
         initial_money : int
             Starting money for each agent.
+        daily_tax : int or float
+            Flat amount of money deducted from each agent every day.
         """
 
         self._agents = []
         self._book = OrderBook()
         self._history = history if history is not None else MarketHistory()
+        self._daily_tax = daily_tax
 
         job_list = list(jobs.all())
         if not job_list:
@@ -95,6 +98,11 @@ class Market(object):
                 daily_sd[good] = trades
 
             self._history.close_day()
+
+            # Deduct daily tax from all agents
+            if self._daily_tax:
+                for agent in self._agents:
+                    agent.apply_tax(self._daily_tax)
 
             agents = [agent for agent in self._agents if not agent.is_bankrupt]
 

--- a/gui/app.py
+++ b/gui/app.py
@@ -32,12 +32,14 @@ def index():
             days = int(data.get('days', 1))
             initial_money = int(data.get('initial_money', 100))
             initial_inv = int(data.get('initial_inv', 10))
+            daily_tax = float(data.get('daily_tax', 0))
             job_counts = data.get('job_counts', {})
         else:
             num_agents = int(request.form.get('num_agents', 9))
             days = int(request.form.get('days', 1))
             initial_money = int(request.form.get('initial_money', 100))
             initial_inv = int(request.form.get('initial_inv', 10))
+            daily_tax = float(request.form.get('daily_tax', 0))
             job_counts = {}
             for key, val in request.form.items():
                 if key.startswith('job_'):
@@ -50,7 +52,8 @@ def index():
                         job_counts[job_name] = count
 
         market = Market(num_agents=num_agents, job_counts=job_counts,
-                        initial_inv=initial_inv, initial_money=initial_money)
+                        initial_inv=initial_inv, initial_money=initial_money,
+                        daily_tax=daily_tax)
         market.simulate(days)
 
         # Collect aggregated statistics and daily price history
@@ -127,11 +130,14 @@ def reset():
     if request.is_json:
         data = request.get_json()
         num_agents = int(data.get('num_agents', 9))
+        daily_tax = float(data.get('daily_tax', 0))
     else:
         num_agents = int(request.form.get('num_agents', 9))
+        daily_tax = float(request.form.get('daily_tax', 0))
     global _history, _persistent_market
     _history.reset()
-    _persistent_market = Market(num_agents=num_agents, history=_history)
+    _persistent_market = Market(num_agents=num_agents, history=_history,
+                                daily_tax=daily_tax)
     data = _compile_results(_persistent_market)
     if request.is_json or request.accept_mimetypes['application/json'] >= request.accept_mimetypes['text/html']:
         return jsonify(data)
@@ -144,9 +150,11 @@ def load():
     global _history, _persistent_market, DB_PATH
     db = request.args.get('db', DB_PATH)
     num_agents = int(request.args.get('num_agents', 9))
+    daily_tax = float(request.args.get('daily_tax', 0))
     DB_PATH = db
     _history = SQLiteHistory(DB_PATH)
-    _persistent_market = Market(num_agents=num_agents, history=_history)
+    _persistent_market = Market(num_agents=num_agents, history=_history,
+                                daily_tax=daily_tax)
     data = _compile_results(_persistent_market)
     if request.accept_mimetypes['application/json'] >= request.accept_mimetypes['text/html']:
         return jsonify(data)

--- a/tests/test_market.py
+++ b/tests/test_market.py
@@ -11,5 +11,12 @@ class TestMarketSimulation(unittest.TestCase):
         market.simulate(5)
         self.assertEqual(len(market.agent_stats()), 4)
 
+    def test_daily_tax_deducts_money(self):
+        market = Market(num_agents=1, job_counts={'Sand Digger': 1},
+                        initial_money=100, daily_tax=5)
+        market.simulate(3)
+        agent_money = market.agent_stats()[0]['money']
+        self.assertEqual(agent_money, 85)
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary
- implement configurable daily tax in `Market`
- allow agents to pay tax at end of each day
- expose tax options in API and README
- test tax behaviour

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6862d3d632dc83248b10809d68a96572