### PR TITLE
Move market history to SQLite by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,10 +53,11 @@ This will print out each agent's activity and the trades executed on each day.
 
 ### Persisting simulation data
 
-`simulate.py` provides a small command line interface that stores all
-trade history in a SQLite database. Run `python simulate.py --step` to
-advance the existing simulation by one day or `python simulate.py --reset`
-to start over from scratch.
+Trade history is now persisted to a SQLite database by default. The
+`simulate.py` helper script can be used to advance the stored simulation or
+reset it entirely. Run `python simulate.py --step` to advance the existing
+simulation by one day or `python simulate.py --reset` to start over from
+scratch.
 
 ## Setup
 

--- a/economy/market/market.py
+++ b/economy/market/market.py
@@ -4,7 +4,7 @@ import random
 from economy.agent import Agent, dump_agent
 from economy import goods, jobs
 from economy.market.book import OrderBook
-from economy.market.history import MarketHistory
+from economy.market.history import SQLiteHistory, MarketHistory
 
 
 class Market(object):
@@ -23,7 +23,8 @@ class Market(object):
             Total number of agents to create if ``job_counts`` is not
             provided.
         history : MarketHistory, optional
-            History backend to use.
+            History backend to use. Defaults to ``SQLiteHistory`` which
+            persists trades to a SQLite database.
         job_counts : dict, optional
             Mapping of job names to the number of agents for that job. When
             supplied ``num_agents`` is ignored and agents are created exactly
@@ -36,7 +37,8 @@ class Market(object):
 
         self._agents = []
         self._book = OrderBook()
-        self._history = history if history is not None else MarketHistory()
+        # Store trade history in SQLite by default
+        self._history = history if history is not None else SQLiteHistory()
         self._lifespans = []
 
         job_list = list(jobs.all())


### PR DESCRIPTION
## Summary
- default `Market` to using `SQLiteHistory`
- mention database persistence in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6862d6a9081883249d56a769bc478238