### PR TITLE
Implement daily tax for agents

### DIFF
--- a/economy/agent.py
+++ b/economy/agent.py
@@ -191,6 +191,10 @@ class Agent(object):
         self._money -= amt
         other._money += amt
 
+    def pay_tax(self, amount):
+        """Deduct a daily flat tax from the agent's money."""
+        self._money -= amount
+
     def give_items(self, item, amt, other):
         self._inventory.remove_item(item, amt)
         other._inventory.add_item(item, amt)

--- a/economy/market/market.py
+++ b/economy/market/market.py
@@ -14,7 +14,7 @@ class Market(object):
     _lifespans = None
 
     def __init__(self, num_agents=15, history=None, job_counts=None,
-                 initial_inv=10, initial_money=100):
+                 initial_inv=10, initial_money=100, daily_tax=1):
         """Create a new market instance.
 
         Parameters
@@ -33,6 +33,8 @@ class Market(object):
             Starting inventory quantity for each agent.
         initial_money : int
             Starting money for each agent.
+        daily_tax : int
+            Flat amount of money deducted from each agent every day.
         """
 
         self._agents = []
@@ -40,6 +42,7 @@ class Market(object):
         # Store trade history in SQLite by default
         self._history = history if history is not None else SQLiteHistory()
         self._lifespans = []
+        self._daily_tax = daily_tax
 
         job_list = list(jobs.all())
         if not job_list:
@@ -101,6 +104,7 @@ class Market(object):
             self._history.close_day()
 
             for agent in self._agents:
+                agent.pay_tax(self._daily_tax)
                 agent.advance_day()
 
             dead_agents = [agent for agent in self._agents if agent.is_bankrupt]

--- a/tests/test_market.py
+++ b/tests/test_market.py
@@ -11,5 +11,12 @@ class TestMarketSimulation(unittest.TestCase):
         market.simulate(5)
         self.assertEqual(len(market.agent_stats()), 4)
 
+    def test_daily_tax_causes_bankruptcy(self):
+        market = Market(num_agents=1, job_counts={'Glass Maker': 1},
+                        initial_inv=0, initial_money=2, daily_tax=1)
+        market.simulate(2)
+        stats = market.overview_stats()
+        self.assertGreater(stats['average_lifespan'], 0)
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary
- add a `pay_tax` method to agents
- support `daily_tax` parameter in `Market`
- deduct tax from agents each day
- test that tax drives bankrupt agents out of the market

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6862db8810688324b1aef52d5edd8833