### PR TITLE
Add agent detail page

### DIFF
--- a/gui/app.py
+++ b/gui/app.py
@@ -114,6 +114,27 @@ def overview():
     return render_template('overview.html', **data)
 
 
+@app.route('/agent/<path:name>', methods=['GET'])
+def agent_detail(name):
+    """Show detailed statistics for a single agent."""
+    agent = next((a for a in _persistent_market._agents if a.name == name), None)
+    if agent is None:
+        return ("Agent not found", 404)
+    inventory = {str(g): qty for g, qty in agent._inventory._items.items()}
+    data = {
+        'name': agent.name,
+        'job': agent.job,
+        'money': agent.money,
+        'total_profit': agent.total_profit,
+        'age': agent.age,
+        'inventory': inventory,
+        'trades': {str(k): v for k, v in agent.trade_stats.items()},
+    }
+    if request.accept_mimetypes['application/json'] >= request.accept_mimetypes['text/html']:
+        return jsonify(data)
+    return render_template('agent.html', **data)
+
+
 @app.route('/step', methods=['POST'])
 def step():
     """Advance the persistent simulation by N days."""

--- a/gui/templates/agent.html
+++ b/gui/templates/agent.html
@@ -1,0 +1,31 @@
+<!doctype html>
+<html>
+  <head>
+    <title>{{ name }} - Agent Details</title>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/foundation-sites/dist/css/foundation.min.css">
+  </head>
+  <body class="grid-container">
+    <h1>{{ name }}</h1>
+    <table class="hover">
+      <tr><th>Job</th><td>{{ job }}</td></tr>
+      <tr><th>Money</th><td>{{ money }}</td></tr>
+      <tr><th>Total Profit</th><td>{{ total_profit }}</td></tr>
+      <tr><th>Age</th><td>{{ age }}</td></tr>
+    </table>
+    <h2>Inventory</h2>
+    <table class="hover">
+      <tr><th>Good</th><th>Quantity</th></tr>
+      {% for good, qty in inventory.items() %}
+      <tr><td>{{ good }}</td><td>{{ qty }}</td></tr>
+      {% endfor %}
+    </table>
+    <h2>Trade Stats</h2>
+    <table class="hover">
+      <tr><th>Good</th><th>Bought</th><th>Sold</th></tr>
+      {% for good, data in trades.items() %}
+      <tr><td>{{ good }}</td><td>{{ data.bought }}</td><td>{{ data.sold }}</td></tr>
+      {% endfor %}
+    </table>
+    <p><a href="/">Back</a></p>
+  </body>
+</html>

--- a/gui/templates/results.html
+++ b/gui/templates/results.html
@@ -63,7 +63,7 @@
       </tr>
       {% for agent in agents %}
       <tr>
-        <td>{{ agent.name }}</td>
+        <td><a href="/agent/{{ agent.name|urlencode }}">{{ agent.name }}</a></td>
         <td>{{ agent.job }}</td>
         <td>{{ agent.money }}</td>
         <td>{{ agent.profit }}</td>
@@ -83,7 +83,7 @@
         {% if agent.trades %}
           {% for good, data in agent.trades.items() %}
           <tr>
-            <td>{{ agent.name }}</td>
+            <td><a href="/agent/{{ agent.name|urlencode }}">{{ agent.name }}</a></td>
             <td>{{ good }}</td>
             <td>{{ data.bought }}</td>
             <td>{{ data.sold }}</td>
@@ -91,7 +91,7 @@
           {% endfor %}
         {% else %}
           <tr>
-            <td>{{ agent.name }}</td>
+            <td><a href="/agent/{{ agent.name|urlencode }}">{{ agent.name }}</a></td>
             <td colspan="3">No trades</td>
           </tr>
         {% endif %}

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -2,6 +2,7 @@ import json
 import unittest
 from pathlib import Path
 import sys
+from urllib.parse import quote
 
 # Ensure project root is on path
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
@@ -74,6 +75,19 @@ class TestSimulationAPI(unittest.TestCase):
         self.assertTrue(resp.is_json)
         data = resp.get_json()
         self.assertEqual(data['days'], 0)
+
+    def test_agent_detail_endpoint(self):
+        resp = self.client.post('/reset', json={'num_agents': 1})
+        self.assertEqual(resp.status_code, 200)
+        data = resp.get_json()
+        agent_name = data['agents'][0]['name']
+        url = '/agent/' + quote(agent_name)
+        resp = self.client.get(url, headers={'Accept': 'application/json'})
+        self.assertEqual(resp.status_code, 200)
+        self.assertTrue(resp.is_json)
+        detail = resp.get_json()
+        self.assertEqual(detail['name'], agent_name)
+        self.assertIn('inventory', detail)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary
- add endpoint to show agent-specific statistics
- link to agent page from results tables
- create HTML template for viewing agent details
- test new `/agent/<name>` endpoint

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6862de3876348324b4be2d5f816cbc29