### PR TITLE
Centralize configuration via environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,22 @@ reset it entirely. Run `python simulate.py --step` to advance the existing
 simulation by one day or `python simulate.py --reset` to start over from
 scratch.
 
+### Configuration
+
+Runtime options such as the database path and default starting resources can be
+set through environment variables:
+
+```
+STAR_TRADER_DB              # SQLite database filename (default: sim.db)
+STAR_TRADER_INITIAL_MONEY   # Starting money for agents (default: 100)
+STAR_TRADER_INITIAL_INV     # Starting inventory per agent (default: 10)
+STAR_TRADER_INVENTORY_SIZE  # Inventory capacity for agents (default: 15)
+STAR_TRADER_DAILY_TAX       # Daily tax deducted from each agent (default: 1)
+```
+
+These values are loaded on startup via `config.py` and used across the
+application.
+
 ## Setup
 
 The project can be run inside a virtual environment to isolate its

--- a/config.py
+++ b/config.py
@@ -1,0 +1,7 @@
+import os
+
+DB_PATH = os.environ.get("STAR_TRADER_DB", "sim.db")
+INITIAL_INVENTORY = int(os.environ.get("STAR_TRADER_INITIAL_INV", "10"))
+INITIAL_MONEY = int(os.environ.get("STAR_TRADER_INITIAL_MONEY", "100"))
+INVENTORY_SIZE = int(os.environ.get("STAR_TRADER_INVENTORY_SIZE", "15"))
+DAILY_TAX = int(os.environ.get("STAR_TRADER_DAILY_TAX", "1"))

--- a/economy/agent.py
+++ b/economy/agent.py
@@ -5,6 +5,11 @@ from .beliefs import Beliefs
 from .offer import Ask, Bid, MIN_PRICE
 from .inventory import Inventory
 from .names import FIRST_NAMES, LAST_NAMES
+from config import (
+    INVENTORY_SIZE as DEFAULT_INVENTORY_SIZE,
+    INITIAL_INVENTORY,
+    INITIAL_MONEY,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -28,7 +33,7 @@ def dump_agent(agent):
 
 
 class Agent(object):
-    INVENTORY_SIZE = 15
+    INVENTORY_SIZE = DEFAULT_INVENTORY_SIZE
     _inventory = None
     _recipe = None
     _market = None
@@ -40,7 +45,8 @@ class Agent(object):
     _age = 0
     beliefs = None
 
-    def __init__(self, recipe, market, initial_inv=10, initial_money=100):
+    def __init__(self, recipe, market, initial_inv=INITIAL_INVENTORY,
+                 initial_money=INITIAL_MONEY):
         self._recipe = recipe
         self._market = market
         self._money = initial_money

--- a/economy/db.py
+++ b/economy/db.py
@@ -1,12 +1,9 @@
-import os
 from contextlib import contextmanager
 from sqlalchemy import create_engine, Column, String, Integer, Float
 from sqlalchemy.orm import sessionmaker, declarative_base
 
-# Reuse the same database file as the simulation history so that all
-# persistent data lives together. Users can override the path via the
-# STAR_TRADER_DB environment variable.
-DB_PATH = os.environ.get("STAR_TRADER_DB", "sim.db")
+# Database path is configured via the shared config module
+from config import DB_PATH
 
 engine = create_engine(f"sqlite:///{DB_PATH}")
 SessionLocal = sessionmaker(bind=engine)

--- a/economy/market/market.py
+++ b/economy/market/market.py
@@ -3,6 +3,8 @@ import random
 
 from economy.agent import Agent, dump_agent
 from economy import goods, jobs
+
+from config import INITIAL_INVENTORY, INITIAL_MONEY, DAILY_TAX
 from economy.market.book import OrderBook
 from economy.market.history import SQLiteHistory, MarketHistory
 
@@ -14,7 +16,8 @@ class Market(object):
     _lifespans = None
 
     def __init__(self, num_agents=15, history=None, job_counts=None,
-                 initial_inv=10, initial_money=100, daily_tax=1):
+                 initial_inv=INITIAL_INVENTORY, initial_money=INITIAL_MONEY,
+                 daily_tax=DAILY_TAX):
         """Create a new market instance.
 
         Parameters

--- a/gui/app.py
+++ b/gui/app.py
@@ -1,5 +1,6 @@
 from flask import Flask, render_template, request, jsonify
-import os
+
+from config import DB_PATH, INITIAL_MONEY, INITIAL_INVENTORY
 
 # Ensure the project root is on the Python path when running this module
 # directly (e.g. `python gui/app.py`). This allows imports like
@@ -16,9 +17,10 @@ if __package__ is None:  # pragma: no cover - executed only when run directly
 from economy import Market, SQLiteHistory, jobs, rebuild_database
 
 # Persistent simulation support
-DB_PATH = os.environ.get("STAR_TRADER_DB", "sim.db")
 _history = SQLiteHistory(DB_PATH)
-_persistent_market = Market(num_agents=9, history=_history)
+_persistent_market = Market(num_agents=9, history=_history,
+                           initial_inv=INITIAL_INVENTORY,
+                           initial_money=INITIAL_MONEY)
 
 
 app = Flask(__name__)
@@ -30,14 +32,14 @@ def index():
             data = request.get_json()
             num_agents = int(data.get('num_agents', 9))
             days = int(data.get('days', 1))
-            initial_money = int(data.get('initial_money', 100))
-            initial_inv = int(data.get('initial_inv', 10))
+            initial_money = int(data.get('initial_money', INITIAL_MONEY))
+            initial_inv = int(data.get('initial_inv', INITIAL_INVENTORY))
             job_counts = data.get('job_counts', {})
         else:
             num_agents = int(request.form.get('num_agents', 9))
             days = int(request.form.get('days', 1))
-            initial_money = int(request.form.get('initial_money', 100))
-            initial_inv = int(request.form.get('initial_inv', 10))
+            initial_money = int(request.form.get('initial_money', INITIAL_MONEY))
+            initial_inv = int(request.form.get('initial_inv', INITIAL_INVENTORY))
             job_counts = {}
             for key, val in request.form.items():
                 if key.startswith('job_'):
@@ -161,7 +163,9 @@ def reset():
         num_agents = int(request.form.get('num_agents', 9))
     global _history, _persistent_market
     _history.reset()
-    _persistent_market = Market(num_agents=num_agents, history=_history)
+    _persistent_market = Market(num_agents=num_agents, history=_history,
+                                initial_inv=INITIAL_INVENTORY,
+                                initial_money=INITIAL_MONEY)
     data = _compile_results(_persistent_market)
     if request.is_json or request.accept_mimetypes['application/json'] >= request.accept_mimetypes['text/html']:
         return jsonify(data)
@@ -176,7 +180,9 @@ def load():
     num_agents = int(request.args.get('num_agents', 9))
     DB_PATH = db
     _history = SQLiteHistory(DB_PATH)
-    _persistent_market = Market(num_agents=num_agents, history=_history)
+    _persistent_market = Market(num_agents=num_agents, history=_history,
+                                initial_inv=INITIAL_INVENTORY,
+                                initial_money=INITIAL_MONEY)
     data = _compile_results(_persistent_market)
     if request.accept_mimetypes['application/json'] >= request.accept_mimetypes['text/html']:
         return jsonify(data)
@@ -194,7 +200,9 @@ def rebuild():
     rebuild_database()
     global _history, _persistent_market
     _history.reset()
-    _persistent_market = Market(num_agents=num_agents, history=_history)
+    _persistent_market = Market(num_agents=num_agents, history=_history,
+                                initial_inv=INITIAL_INVENTORY,
+                                initial_money=INITIAL_MONEY)
     data = _compile_results(_persistent_market)
     if request.is_json or request.accept_mimetypes['application/json'] >= request.accept_mimetypes['text/html']:
         return jsonify(data)


### PR DESCRIPTION
## Summary
- add `config.py` with environment-driven defaults
- use config values for database path, inventory size and starting resources
- document environment variables in README

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686469fd3cc083248ae73e6fe174e53f