### PR TITLE
Encapsulate Market state via properties

### DIFF
--- a/economy/market/market.py
+++ b/economy/market/market.py
@@ -248,6 +248,18 @@ class Market(object):
     def aggregate(self, good, depth=None):
         return self._history.aggregate(good, depth)
 
+    # -- Read-only accessors -------------------------------------------------
+
+    @property
+    def agents(self):
+        """Return a copy of the active agents list."""
+        return list(self._agents)
+
+    @property
+    def day_number(self):
+        """Current simulation day number."""
+        return self._history.day_number
+
     def agent_stats(self):
         stats = []
         for agent in self._agents:
@@ -273,7 +285,7 @@ class Market(object):
         if self._lifespans:
             avg_life = sum(self._lifespans) / len(self._lifespans)
         return {
-            "days_elapsed": self._history.day_number,
+            "days_elapsed": self.day_number,
             "active_agents": len(self._agents),
             "average_age": avg_age,
             "average_lifespan": avg_life,

--- a/gui/app.py
+++ b/gui/app.py
@@ -99,7 +99,7 @@ def index():
 
 def _compile_results(market):
     """Helper to build the results dict for templates/JSON."""
-    days = market._history.day_number
+    days = market.day_number
     hist = market.history(days)
     results = {}
     for good in hist:
@@ -136,7 +136,7 @@ def overview():
 @bp.route("/agent/<path:name>", methods=["GET"])
 def agent_detail(name):
     """Show detailed statistics for a single agent."""
-    agent = next((a for a in _persistent_market._agents if a.name == name), None)
+    agent = next((a for a in _persistent_market.agents if a.name == name), None)
     if agent is None:
         return ("Agent not found", 404)
     inventory = {str(g): qty for g, qty in agent._inventory._items.items()}


### PR DESCRIPTION
## Summary
- add `agents` and `day_number` read-only accessors on `Market`
- use accessors from the web API

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68647d09c410832492bc6cd939c67b34