### PR TITLE
Integrate Flask-SQLAlchemy

### DIFF
--- a/economy/db.py
+++ b/economy/db.py
@@ -1,6 +1,7 @@
 from contextlib import contextmanager
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
+from flask_sqlalchemy import SQLAlchemy
 
 # Database path is configured via the shared config module
 from config import DB_PATH
@@ -14,8 +15,21 @@ from .schema import (
     JobTool,
 )
 
+db_ext = SQLAlchemy()
+
 engine = create_engine(f"sqlite:///{DB_PATH}")
 SessionLocal = sessionmaker(bind=engine)
+
+
+def init_app(app):
+    """Initialize Flask-SQLAlchemy with the given app."""
+    app.config.setdefault("SQLALCHEMY_DATABASE_URI", f"sqlite:///{DB_PATH}")
+    app.config.setdefault("SQLALCHEMY_TRACK_MODIFICATIONS", False)
+    db_ext.init_app(app)
+    global engine, SessionLocal
+    with app.app_context():
+        engine = db_ext.engine
+        SessionLocal.configure(bind=engine)
 
 
 def get_session():

--- a/gui/app.py
+++ b/gui/app.py
@@ -1,5 +1,7 @@
 from flask import Flask, Blueprint, render_template, request, jsonify
 
+from economy.db import init_app as init_db
+
 from config import DB_PATH, INITIAL_MONEY, INITIAL_INVENTORY
 
 # Ensure the project root is on the Python path when running this module
@@ -254,6 +256,7 @@ def rebuild():
 
 
 app = Flask(__name__)
+init_db(app)
 app.register_blueprint(bp)
 
 if __name__ == "__main__":

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,5 +4,5 @@ matplotlib
 pytest
 flask
 sqlalchemy
+flask_sqlalchemy
 plotly
-


### PR DESCRIPTION
## Summary
- add Flask-SQLAlchemy to requirements
- provide `init_app()` helper in `economy.db` using Flask-SQLAlchemy
- initialize the extension in `gui/app.py`

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6864aa8896f883249b17b5dd2c99f9d3