### PR TITLE
Add plugin system

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,4 +104,9 @@ Open your browser at [http://localhost:5000](http://localhost:5000) to configure
 
 The results page now includes a table showing the average price of each good for every simulated day, allowing you to track price trends over time.
 It also lists statistics for each agent, including their final money and total profit, so you can compare how well different strategies performed. An additional table breaks down how many units of each good every agent bought and sold during the run. The price and volume charts on this page are rendered with **Plotly** so you can hover and zoom for a closer look at the data.
-\nSee **REFACTORING.md** for ideas on improving the codebase.
+
+## Plugins
+
+Modules placed in the top-level `plugins` package are loaded automatically when a `Market` instance is created. Plugins can define additional `Good` and `Job` objects or register custom `Agent` subclasses via `economy.plugins.register_agent` to extend the simulation.
+
+See **REFACTORING.md** for ideas on improving the codebase.

--- a/economy/market/market.py
+++ b/economy/market/market.py
@@ -3,6 +3,7 @@ import random
 
 from economy.agent import Agent, dump_agent
 from economy import goods, jobs
+from economy.plugins import load_plugins, agent_for_job
 
 from config import INITIAL_INVENTORY, INITIAL_MONEY, DAILY_TAX
 from economy.market.book import OrderBook
@@ -53,6 +54,9 @@ class Market(object):
         self._lifespans = []
         self._daily_tax = daily_tax
 
+        # Load any external plugins before creating agents
+        load_plugins()
+
         job_list = list(jobs.all())
         if not job_list:
             return
@@ -65,8 +69,9 @@ class Market(object):
                     continue
 
                 for _ in range(int(count)):
+                    agent_cls = agent_for_job(str(recipe))
                     self._agents.append(
-                        Agent(
+                        agent_cls(
                             recipe,
                             self,
                             initial_inv=initial_inv,
@@ -84,8 +89,9 @@ class Market(object):
 
             for recipe in job_list:
                 for _ in range(agents_per_job):
+                    agent_cls = agent_for_job(str(recipe))
                     self._agents.append(
-                        Agent(
+                        agent_cls(
                             recipe,
                             self,
                             initial_inv=initial_inv,
@@ -94,8 +100,9 @@ class Market(object):
                     )
 
             for recipe in job_list[:leftover]:
+                agent_cls = agent_for_job(str(recipe))
                 self._agents.append(
-                    Agent(
+                    agent_cls(
                         recipe,
                         self,
                         initial_inv=initial_inv,
@@ -186,7 +193,8 @@ class Market(object):
         else:
             recipe = random.choice(list(jobs.all()))
 
-        return Agent(recipe, self)
+        agent_cls = agent_for_job(str(recipe))
+        return agent_cls(recipe, self)
 
     def make_charts(self):
         """Generate interactive charts for price and volume using Plotly."""

--- a/economy/plugins.py
+++ b/economy/plugins.py
@@ -1,0 +1,48 @@
+import importlib
+import pkgutil
+from typing import Dict, Type
+
+from economy.agent import Agent
+
+_loaded = False
+_agent_classes: Dict[str, Type[Agent]] = {}
+_job_agents: Dict[str, Type[Agent]] = {}
+
+
+def register_agent(cls: Type[Agent], job: str | None = None) -> None:
+    """Register a custom Agent subclass.
+
+    Parameters
+    ----------
+    cls : Type[Agent]
+        The Agent subclass to register.
+    job : str, optional
+        Name of the job this agent should handle. If provided the market
+        will use this class when spawning agents for that job.
+    """
+    name = cls.__name__
+    _agent_classes[name] = cls
+    if job:
+        _job_agents[job.lower()] = cls
+
+
+def agent_for_job(job: str) -> Type[Agent]:
+    """Return the Agent class registered for ``job`` if any."""
+    return _job_agents.get(job.lower(), Agent)
+
+
+def load_plugins() -> None:
+    """Import all modules in the top-level ``plugins`` package."""
+    global _loaded
+    if _loaded:
+        return
+    try:
+        import plugins  # type: ignore
+    except Exception:
+        _loaded = True
+        return
+    for finder, name, ispkg in pkgutil.iter_modules(plugins.__path__):
+        module = importlib.import_module(f"plugins.{name}")
+        if hasattr(module, "register"):
+            module.register()
+    _loaded = True


### PR DESCRIPTION
## Summary
- load plugins at market startup
- create plugin registry to allow registering custom agents
- allow retrieving agent class by job
- document plugin usage in README

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6864c984fbc48324b16b4e1078c7d582